### PR TITLE
Updates based on tests on RPI 1

### DIFF
--- a/zigbee2mqtt/README.md
+++ b/zigbee2mqtt/README.md
@@ -4,4 +4,4 @@ This is just a configuration stub to make the Hass.io repository work.
 
 The add-on itself can be found at the following URL:
 
-<https://github.com/Koenkk/zigbee2mqtt-hassio-addon/zigbee2mqtt>
+<https://github.com/Koenkk/zigbee2mqtt-hassio-addon/tree/master/zigbee2mqtt>

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Zigbee2mqtt",
-    "version": "0.1",
+    "version": "latest",
     "slug": "zigbee2mqtt",
     "description": "Zigbee to MQTT bridge, get rid of your proprietary Zigbee bridges",
     "url": "https://github.com/Koenkk/zigbee2mqtt-hassio-addon/zigbee2mqtt",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -11,5 +11,12 @@
         "armhf"
     ],
     "boot": "auto",
-    "image": "koenkk/zigbee2mqtt-hassioaddon-{arch}"
+    "image": "koenkk/zigbee2mqtt-hassioaddon-{arch}",
+    "devices": ["/dev/ttyACM0:/dev/ttyACM0:rwm"],
+    "options": {
+        "mqtt_host": "mqtt://localhost"
+      },
+      "schema": {
+        "mqtt_host": "str"
+      }
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -12,6 +12,7 @@
     ],
     "boot": "auto",
     "image": "koenkk/zigbee2mqtt-hassioaddon-{arch}",
+    "host_network": true,
     "devices": ["/dev/ttyACM0:/dev/ttyACM0:rwm"],
     "options": {
         "mqtt_host": "mqtt://localhost"


### PR DESCRIPTION
Find some changes and hacks to make it work on RPI1

Things to do:
- [ ] Allow mqtt host to be configurable to remove the need for "host_network": true
- [ ] Make the db map to a folder that is sitting on the host (I think /data) to avoid losing all data on addon restart - maybe make it absolute path and add it as option
- [ ] Expose permit_join to allow turning it off from the interface
- [ ] Make proper use of the version to avoid "latest" version hack that causes stacktrace
- [ ] Auto restart when addon stops because of zigbee-shepherd bug https://github.com/Koenkk/zigbee2mqtt/issues/29 ? Or maybe find a better way of error handling this inside the library to avoid a total crash of the process?
- [ ] Allow device path /dev/ttyACM0 to be configurable - is the config: "devices": ["/dev/ttyACM0:/dev/ttyACM0:rwm"] needed ?